### PR TITLE
Do not use Mix.env/0 at runtime

### DIFF
--- a/lib/elixir_authorizenet.ex
+++ b/lib/elixir_authorizenet.ex
@@ -84,11 +84,7 @@ defmodule AuthorizeNet do
   end
 
   defp uri() do
-    if Mix.env === :test do
-      config :test_server_uri
-    else
-      @uris[config(:environment)]
-    end
+    config(:test_server_uri) || Keyword.fetch!(@uris, config(:environment))
   end
 
   defp config(key) do


### PR DESCRIPTION
because it may not be available after the code is compiled (for example in a release).

Just use the test server if the `:test_server_uri` config is set.

Fixes #1.